### PR TITLE
Try to get rid of Grub GUI prompt that breaks installation on ubuntu-trusty-14.04-amd64-server-20140607.1 (ami-e7b8c0d7)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,8 @@
 
 set -xe
 
+unset UCF_FORCE_CONFFOLD
+export UCF_FORCE_CONFFNEW=YES
 export DEBIAN_FRONTEND=noninteractive
 
 if [ ! -e /usr/lib/apt/methods/https ]; then
@@ -15,7 +17,7 @@ echo deb https://dokku-alt.github.io/dokku-alt / > /etc/apt/sources.list.d/dokku
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 apt-key adv --keyserver keys.gnupg.net --recv-keys EAD883AF
 apt-get update
-apt-get install -y dokku-alt ruby ruby-sinatra
+apt-get install -o Dpkg::Options::="--force-confnew" --yes --force-yes dokku-alt ruby ruby-sinatra
 
 set +xe
 


### PR DESCRIPTION
I just tested this with the AMI in the title and the installation was a breeze!

Source, with some modifications:
http://askubuntu.com/questions/146921/how-do-i-apt-get-y-dist-upgrade-without-a-grub-config-prompt
