### PR TITLE
Fix nginx/elb

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -63,9 +63,6 @@ cat<<EOF >> $DOKKU_ROOT/$APP/nginx.conf
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_set_header Host \$http_host;
-    proxy_set_header X-Forwarded-Proto \$scheme;
-    proxy_set_header X-Forwarded-For \$remote_addr;
-    proxy_set_header X-Forwarded-Port \$server_port;
     proxy_set_header X-Request-Start \$msec;
   }
 }
@@ -96,9 +93,6 @@ cat<<EOF >> $DOKKU_ROOT/$APP/nginx.conf
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_set_header Host \$http_host;
-    proxy_set_header X-Forwarded-Proto \$scheme;
-    proxy_set_header X-Forwarded-For \$remote_addr;
-    proxy_set_header X-Forwarded-Port \$server_port;
     proxy_set_header X-Request-Start \$msec;
   }
 }


### PR DESCRIPTION
These headers override the headers set by load balancers (like ELB) which means if you terminate SSL at the load balancer level your app doesn't know about it.
