### PR TITLE
Configurable NGINX listen address

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen. I
 * HTTP-Basic Auth support (BETA)
 * Simple SSL commands (BETA)
 * SPDY and HSTS (BETA)
+* Configure NGINX listen address (BETA)
 
 ### Planned features:
 
@@ -351,6 +352,8 @@ Example:
 * `MONGODB_IMAGE` – Docker image to be used for MongoDB plugin, defaults to [`ayufan/dokku-alt-mongodb`](https://registry.hub.docker.com/u/ayufan/dokku-alt-mongodb/).
 * `POSTGRESQL_IMAGE` – Docker image to be used for PostgreSQL plugin, defaults to [`ayufan/dokku-alt-postgresql`](https://registry.hub.docker.com/u/ayufan/dokku-alt-postgresql/).
 * `REDIS_IMAGE` – Docker image to be used for Redis plugin, defaults to [`ayufan/dokku-alt-redis`](https://registry.hub.docker.com/u/ayufan/dokku-alt-redis/).
+* `DOKKU_LISTEN_IPV4` (BETA) - Set the IPV4 address on which NGINX will listen for requests
+* `DOKKU_LISTEN_IPV6` (BETA) - Set the IPV6 address on which NGINX will listen for requests
 * `DOKKU_FORCE_ENABLE_HSTS` (BETA) - Force to enable HSTS header (validity for one year) for all TLS-enabled apps
 * `DOKKU_DISABLE_NGINX_X_FORWARDED` (BETA) - Disable setting of `X-Forwarded` headers by nginx, useful for CDN installations.
 

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -19,6 +19,8 @@ hostnames_for_app "$APP"
 http_host() {
   [[ $# -le 1 ]] && return
 
+  DOKKU_LISTEN_IPV4="${DOKKU_LISTEN_IPV4:-*}"
+  DOKKU_LISTEN_IPV6="${DOKKU_LISTEN_IPV6:-[::]}"
   SCHEME="$1"
   shift
 
@@ -28,8 +30,8 @@ EOF
 
   if [[ "$SCHEME" == "https" ]]; then
     cat <<EOF
-  listen      [::]:443 ssl spdy;
-  listen      443 ssl spdy;
+  listen      $DOKKU_LISTEN_IPV6:443 ssl spdy;
+  listen      $DOKKU_LISTEN_IPV4:443 ssl spdy;
   server_name $@;
 
   keepalive_timeout   70;
@@ -56,8 +58,8 @@ EOF
 
   else
     cat <<EOF
-  listen      [::]:80;
-  listen      80;
+  listen      $DOKKU_LISTEN_IPV6:80;
+  listen      $DOKKU_LISTEN_IPV4:80;
   server_name $@;
 
 EOF
@@ -112,8 +114,8 @@ http_redirect() {
 
   cat<<EOF
 server {
-  listen      [::]:80;
-  listen      80;
+  listen      $DOKKU_LISTEN_IPV6:80;
+  listen      $DOKKU_LISTEN_IPV4:80;
   server_name $@;
   return 302 $SCHEME://$hostname\$request_uri;
 }


### PR DESCRIPTION
Make the address on which NGINX listens for web requests configurable by
setting DOKKU_LISTEN_IPV4 and DOKKU_LISTEN_IPV6 in dokkurc.
