### PR TITLE
Always set X-Forwarded-For / Keep all forwarding information

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -87,7 +87,7 @@ EOF
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_set_header Host \$http_host;
-    proxy_set_header X-Forwarded-For \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
 EOF
 
   if [[ -z "$DOKKU_DISABLE_NGINX_X_FORWARDED" ]]; then


### PR DESCRIPTION
Since NGINX is acting as a reverse proxy the X-Forwarded-For Header should always be set, independent of HTTP or HTTPS connections. 

Also NGINX provides a variable that keeps the whole forwarding information available if the X-Forwarded-For Header has been set by a proxy server further up in the connection chain.
