### PR TITLE
Fixed adding SSL key

### DIFF
--- a/plugins/ssl/commands
+++ b/plugins/ssl/commands
@@ -32,7 +32,7 @@ case "$1" in
     verify_max_args 2 "$@"
     mkdir -p "$APP_DIR/ssl"
     KEY=$(cat)
-    echo "$KEY" | openssl rsa -in privateKey.key -check
+    echo "$KEY" | openssl rsa -check
     echo "$KEY" > "$APP_DIR/ssl/server.key"
 
     [[ ! -f "$APP_DIR/ssl/server.crt" ]] || dokku deploy "$APP"


### PR DESCRIPTION
Fixes bug that made impossible to add new ssl key.

```
root@maggie:~# cat server.key | dokku ssl:key maggie
Error opening Private Key privateKey.key
139883262244512:error:0200100D:system library:fopen:Permission denied:bss_file.c:398:fopen('privateKey.key','r')
139883262244512:error:20074002:BIO routines:FILE_CTRL:system lib:bss_file.c:400:
unable to load Private Key
```

is now

```
root@maggie:~# cat server.key | dokku ssl:key maggie
RSA key ok
writing RSA key
-----BEGIN RSA PRIVATE KEY-----
...
-----END RSA PRIVATE KEY-----
-----> Deploying maggie ...
-----> Shutting down old containers
=====> Application deployed:
```
