### PR TITLE
Add the GIT_REV environment variable to /app/.profile.d

### DIFF
--- a/plugins/dokku-git-rev/post-build
+++ b/plugins/dokku-git-rev/post-build
@@ -4,8 +4,15 @@ source "$(dirname $0)/../dokku_common"
 
 verify_app_name "$1"
 
-if [[ "$2" != "" ]]; then
-      cat <<EOF | docker build -t "$IMAGE" -
+[[ -z "$2" ]] && exit 0
+
+if is_image_buildstep_based "$IMAGE"; then
+  echo '-----> Injecting git revision'
+  id=$(echo "export GIT_REV=${2}" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /app/.profile.d/git-rev.sh")
+  test $(docker wait $id) -eq 0
+  docker commit $id $IMAGE > /dev/null
+else
+  cat <<EOF | docker build -t "$IMAGE" -
 FROM $IMAGE
 ENV GIT_REV $2
 EOF


### PR DESCRIPTION
This allows child processes which might not have access to the
original environment to source the profile.d directory and gain
access to the information.

Additional bonus is that the output when pushing an app is much cleaner compared to using a Dockerfile.
