### PR TITLE
Redirect to http if there is no ssl at all

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -156,7 +156,7 @@ if [[ "$hostname" != "" ]]; then
   else
     # default nginx.conf
     http_host http ${hostnames[@]} >> $DOKKU_ROOT/$APP/nginx.conf
-    http_redirect "https://$hostname\$request_uri" ${redirect_hostnames[@]} >> $DOKKU_ROOT/$APP/nginx.conf
+    http_redirect "http://$hostname\$request_uri" ${redirect_hostnames[@]} >> $DOKKU_ROOT/$APP/nginx.conf
 
     echo "http://$hostname" > "$DOKKU_ROOT/$APP/URL"
   fi


### PR DESCRIPTION
In `else` clause there is no ssl enabled at all. So redirect domains just don't work. It's perfectly reasonable that in case of both http and https we use https, but when there is no https at all, we should redirect to http.
