### PR TITLE
Updated labels for preboot

### DIFF
--- a/plugins/01_dokku-preboot/commands
+++ b/plugins/01_dokku-preboot/commands
@@ -44,8 +44,8 @@ case "$1" in
     preboot:status <app>                Status of specific app
     preboot:enable <app>                Enable specific app
     preboot:disable <app>               Stop specific app
-    preboot:wait:time <app> <secs>      Restart specific app (not-redeploy)
-    preboot:cooldown:time <app> <secs>  Re-enable specific app
+    preboot:wait:time <app> <secs>      Set the wait time
+    preboot:cooldown:time <app> <secs>  Set the cooldown time
 EOF
     ;;
 


### PR DESCRIPTION
Hi,
I found this mis-documentation and thought of fixing it.

I found it while asking myself: what's the difference between the wait time and the cooldown time? at what point is nginx reloaded and the requests start to point to the new container?