### PR TITLE
Adding better nginx header support

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -39,6 +39,9 @@ EOF
   keepalive_timeout   70;
   add_header Alternate-Protocol 443:npn-spdy/2;
 
+  underscores_in_headers on;
+  ignore_invalid_headers off;
+   
   ssl on;
   ssl_certificate     $SSL_INUSE/server.crt;
   ssl_certificate_key $SSL_INUSE/server.key;
@@ -92,6 +95,7 @@ EOF
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_set_header Host \$http_host;
+    proxy_pass_request_headers on;
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
 EOF
 


### PR DESCRIPTION
Some upstream apps require access to the originating client HTTP header.  This change would allow the upstream to see any request headers as nginx would.

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass_request_headers
http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers
http://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers