### PR TITLE
Use tabs to delimit columns.

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -25,7 +25,7 @@ if [[ $1 == config ]] || [[ $1 == config:* ]]; then
 fi
 
 config_styled_hash () {
-  sed 's/^\(.*\)=/\1:=/g' | column -t -s '='
+  sed 's/^\([^=]*\)=/\1:\t/g' | column -t -s '\t'
 }
 
 config_shell_hash() {
@@ -152,4 +152,3 @@ EOF
     ;;
 
 esac
-


### PR DESCRIPTION
This avoids the columns breaking when an environment variable value contains an '='.