### PR TITLE
Fix display of variables with = in.

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -25,7 +25,7 @@ if [[ $1 == config ]] || [[ $1 == config:* ]]; then
 fi
 
 config_styled_hash () {
-  sed 's/^\([^=]*\)=/\1:\t/g' | column -t -s '\t'
+  sed 's/^\([^=]*\)=/\1:|/g' | column -t -s '|'
 }
 
 config_shell_hash() {


### PR DESCRIPTION
Use a character less likely to be in an environment variable.

We're restricted by the fact that `column` can't use a sequence, only a single character. On OS X column won't interpret \t either.