### PR TITLE
Add support for ssh-dss keys

### DIFF
--- a/plugins/acl/commands
+++ b/plugins/acl/commands
@@ -29,7 +29,7 @@ case "$1" in
   access:list)
     verify_max_args 1 "$@"
 
-    sed -n -e 's/^command="FINGERPRINT=\(.*\) NAME=\(.*\) `.*ssh-\(rsa\|dsa\).*$/\2\t\1/p' "$AUTHORIZED_KEYS"
+    sed -n -e 's/^command="FINGERPRINT=\(.*\) NAME=\(.*\) `.*ssh-\(rsa\|dsa\|dss\).*$/\2\t\1/p' "$AUTHORIZED_KEYS"
     ;;
 
   access:info)


### PR DESCRIPTION
See http://security.stackexchange.com/questions/51567/why-are-dsa-keys-referred-to-as-dss-keys-when-used-with-ssh