### PR TITLE
Protect against POODLE vulnerability

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -154,6 +154,7 @@ server {
   ssl on;
   ssl_certificate     $SSL_INUSE/server.crt;
   ssl_certificate_key $SSL_INUSE/server.key;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   return 301 $WHERE;
 }
 EOF


### PR DESCRIPTION
Ubuntu's nginx is vulnerable to POODLE. While the website https properly includes a ssl_protocol directive as recommended by
https://www.digitalocean.com/community/tutorials/how-to-protect-your-server-against-the-poodle-sslv3-vulnerability 
the redirect code does not have the protocol set, and the website receives bad grades  on https://www.ssllabs.com/ssltest/.

This patch should also disable TLSv3 in redirects.