### PR TITLE
Use quoted env-var values in config_shell_hash()

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -28,12 +28,17 @@ config_styled_hash () {
   sed 's/^\([^=]*\)=/\1:|/g' | column -t -s '|'
 }
 
+escape_single_quotes (){
+  sed "s|'|'\\\''|g"
+}
+
 config_shell_hash() {
   while read var
   do
     KEY=`echo "$var" | cut -d"=" -f1`
     VALUE=`echo "$var" | cut -d"=" -f2-`
-    echo "export $(printf "%q" "$KEY")=$(printf "%q" "$VALUE")"
+    # Prevent printf %q in env-var value, instead manually escape single quotes
+    echo "export $(printf "%q" "$KEY")='$(echo "$VALUE" | escape_single_quotes)'"
   done
 }
 


### PR DESCRIPTION
This would solve https://github.com/dokku-alt/dokku-alt/issues/204

I encountered this situation because I set an env-var to an url with a query at the end and `printf %q` escaped the `?`. This would be then written to `/app/.env` and foreman would start the app and read the environment from there. Since the value in the `.env` file is not quoted, unescaping does not occur as it would typically happen with a regular export. As a result the value on the env var inside my app is the escaped string, not the result of interpreting the escaped characters.

This closes https://github.com/dokku-alt/dokku-alt/issues/204 is you accept the merge.

I have opened an issue to discuss this in dotenv here: https://github.com/bkeepers/dotenv/issues/170

Thanks.