### PR TITLE
Really adding nginx header proxy support.

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -91,6 +91,9 @@ EOF
   done
 
   cat <<EOF
+    underscores_in_headers on;
+    ignore_invalid_headers off;
+
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
A previous pull request added these options allowing underscores in request headers, however, these options only are added for https. This adds them for http as well.