### PR TITLE
adding a check for sudo

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,10 @@ if [ ! -e /usr/lib/apt/methods/https ]; then
 	apt-get install -y apt-transport-https
 fi
 
+if [ ! -e /usr/bin/sudo ]; then
+  apt-get install sudo
+fi
+
 echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 echo deb https://dokku-alt.github.io/dokku-alt / > /etc/apt/sources.list.d/dokku-alt.list
 


### PR DESCRIPTION
Hi,

It turns out sudo isn't part of the default Debian Jessie install.

I've added a check for it in this pull request.

Thanks,
Jason
