### PR TITLE
tutum-agent uninstalls dokku-alt

### DIFF
--- a/deb/dokku-alt/DEBIAN/control
+++ b/deb/dokku-alt/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 0.3.0
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, software-properties-common, man-db, lxc-docker (>= 1.3.0), nginx, dnsutils, linux-image-extra-virtual, aufs-tools, apache2-utils
+Depends: locales, git, make, curl, software-properties-common, man-db, lxc-docker (>= 1.3.0) | tutum-agent, nginx, dnsutils, linux-image-extra-virtual, aufs-tools, apache2-utils
 Provides: dokku-alt
 Maintainer: Kamil Trzciński <ayufan@ayufan.eu>
 Description: Docker powered mini-Heroku an fork of Dokku the Dokku Alternative.


### PR DESCRIPTION
Tutum is a service to manage nodes with Docker inside them. Checkout the website on [tutum.co]

tutum-agent, which is the software that must be installed on each node to be managed by the Tutum service includes its own version of Docker embedded in the package (docker 1.5).

Installing both Dokku and Tutum on the same machine will result in one being deleted because the package tutum-agent replaces lxc-docker and Dokku depends on it, so it is deleted too.

I propose using tutum-agent as an alternative to lxc-docker.