### PR TITLE
Make TLS command docs readable without scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,11 +371,11 @@ Dokku provides easy TLS support out of the box. To enable TLS connection to your
 
 Dokku-alt extends this even further by allowing you to use command line interface for certificates:
 
-    ssl:generate <app>                              Generate certificate signing request for an APP
-    ssl:certificate <app>                           Pipe signed certifcate with all intermediates for an APP
-    ssl:forget <app>                                Wipes certificate for an APP
-    ssl:info <app>                                  Show info about certifcate and certificate request
-    ssl:key <app>                                   Pipe private key for an APP
+    ssl:generate <app>          Generate certificate signing request for an APP
+    ssl:certificate <app>       Pipe signed certifcate with all intermediates for an APP
+    ssl:forget <app>            Wipes certificate for an APP
+    ssl:info <app>              Show info about certifcate and certificate request
+    ssl:key <app>               Pipe private key for an APP
 
 First use: `dokku ssl:generate myapp` to generate certificate signing request (CSR). At the end of process you will receive `BEGIN CERTIFICATE REQUEST` which you can ten copy-n-paste to your SSL signer (ie. http://startssl.com).
 


### PR DESCRIPTION
In the TLS Support section, the commands had a lot of spaces after them so the descriptions required scrolling to read. I removed the spaces so it fits on the screen without scrolling.