### PR TITLE
Upgrade docker version to docker-engine 1.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,15 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Install docker
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
-	echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list && \
+#RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+#	echo deb https://apt.dockerproject.org/repo ubuntu-wily main > /etc/apt/sources.list.d/docker.list && \
+#	apt-get update && \
+#	apt-get -y install docker-engine
+
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+	echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list && \
 	apt-get update && \
-	apt-get install -y lxc-docker
+	apt-get -y install docker-engine
 
 # Install forego
 RUN curl -o /usr/bin/forego https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego && chmod +x /usr/bin/forego
@@ -32,7 +37,7 @@ VOLUME /home/dokku
 VOLUME /var/lib/docker
 
 # Install dokku-alt
-ADD / /srv/dokku-alt
+ADD . /srv/dokku-alt
 WORKDIR /srv/dokku-alt
 RUN sed -i 's/linux-image-extra-virtual, //g' deb/dokku-alt/DEBIAN/control
 RUN make install

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 nginx: exec nginx -g "daemon off; error_log /dev/stdout info;"
 ssh: mkdir /var/run/sshd; exec /usr/sbin/sshd -De
 dokku: exec /srv/dokku-alt/start-dokku.sh
-docker: cgroups-mount; exec docker -d
+docker: cgroups-mount; exec docker daemon

--- a/deb/dokku-alt/DEBIAN/control
+++ b/deb/dokku-alt/DEBIAN/control
@@ -1,9 +1,9 @@
 Package: dokku-alt
-Version: 0.3.0
+Version: 0.3.1
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, software-properties-common, man-db, lxc-docker (>= 1.3.0), nginx, dnsutils, linux-image-extra-virtual, aufs-tools, apache2-utils
+Depends: locales, git, make, curl, software-properties-common, man-db, docker-engine (>= 1.10.0-0~trusty), nginx, dnsutils, linux-image-extra-virtual, aufs-tools, apache2-utils
 Provides: dokku-alt
 Maintainer: Kamil Trzciński <ayufan@ayufan.eu>
 Description: Docker powered mini-Heroku an fork of Dokku the Dokku Alternative.


### PR DESCRIPTION
Fix #305 
Change dokku-alt packaging in Docker to use docker-engine instead of lxc-docker.
Change docker version to integrate new docker version 1.10.0.