### PR TITLE
Mark project as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dokku Alternative
 
+> Unmaintained, Migrate to [Dokku](https://github.com/dokku/dokku) as soon as possible
+
 [![Join the chat at https://gitter.im/dokku-alt/dokku-alt](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dokku-alt/dokku-alt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen. It's a fork of the original [dokku](https://github.com/progrium/dokku). The idea behind this fork is to provide complete solution with plugins covering most use-cases which are stable and well tested.


### PR DESCRIPTION
Users are somehow _still_ stumbling upon dokku-alt and complaining about both dokku-alt _and_ dokku. Rather than letting users assume this project is still good to go, point them in the direction of a supported project.

Note: I'd also like it if you renamed the project, since it causes some confusion from time to time, but thats less likely to happen than this is. My main concern is users having a bad experience and then complaining about an unrelated project (Dokku).
